### PR TITLE
Fixed incorrect Travis Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # A fuzzy receipt parser written in Python
-<br>[![Build Status](https://travis-ci.org/rmad17/receipt-parser.svg?branch=master)](https://travis-ci.org/rmad17/receipt-parser)<br>
+<br>[![Build Status](https://travis-ci.org/mre/receipt-parser.svg?branch=master)](https://travis-ci.org/mre/receipt-parser)<br>
 Updating your housekeeping book is a tedious task: You need to manually find the shop name, the date and the total from every receipt. Then you need to write it down. At the end you want to calculate a sum of all bills. Nasty. So why not let a machine do it?
 
 This is a fuzzy receipt parser written in Python. You give it any dirty old receipt lying around and it will try its best to find the correct data for you.


### PR DESCRIPTION
Apologies for the incorrect travis link. I had added my travis link instead of yours. Here is a fix for it. Please sign in to Travis from your Github account and enable Travis for this repo. 